### PR TITLE
Automate releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,3 +36,46 @@ jobs:
           command: goveralls -coverprofile=$CIRCLE_ARTIFACTS/profile.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
       - store_test_results:
           path: /tmp/test-reports
+  release:
+    docker:
+      - image: circleci/golang:1.10
+    working_directory: /go/src/github.com/nimona/go-nimona
+    steps:
+      - checkout
+      - run:
+          name: Install tools
+          command: |
+            curl -L https://github.com/golang/dep/raw/master/install.sh | sh
+            go get github.com/goreleaser/goreleaser
+      - run:
+          name: Install dependencies
+          command: dep ensure
+      - run:
+          name: Run goreleaser
+          command: goreleaser
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              ignore: /^[0-9]+(\.[0-9]+)*/
+  build-and-release:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+(\.[0-9]+)*/
+      - release:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+(\.[0-9]+)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,6 @@ jobs:
           name: Install dependencies
           command: dep ensure
       - run:
-          name: Build everything
-          command: go build -v ./...
-      - run:
           name: Run tests
           command: |
             mkdir -p /tmp/test-reports/core
@@ -36,6 +33,9 @@ jobs:
           command: goveralls -coverprofile=$CIRCLE_ARTIFACTS/profile.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
       - store_test_results:
           path: /tmp/test-reports
+      - run:
+          name: Ensure code actually builds
+          command: make build
   release:
     docker:
       - image: circleci/golang:1.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Install tools
           command: |
-            go get -u github.com/golang/dep/cmd/dep
+            curl -L https://github.com/golang/dep/raw/master/install.sh | sh
             go get -u github.com/axw/gocov/gocov
             go get -u github.com/mattn/goveralls
             go get -u github.com/jstemmer/go-junit-report

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ debug
 
 # build directories
 bin/*
+dist/*
 
 # Vendor
 vendor

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,36 @@
+project_name: nimona
+builds:
+  - main: cmd/nimona/main.go
+    binary: nimona
+    flags: -a
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - freebsd
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+      - arm
+    goarm:
+      - 6
+      - 7
+archive:
+  name_template: '{{ .ProjectName }}-{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm
+    }}v{{ .Arm }}{{ end }}'
+  format: tar.gz
+  wrap_in_directory: true
+  format_overrides:
+    - goos: windows
+      format: zip
+before:
+  hooks:
+    - make clean
+git:
+  short_hash: true
+snapshot:
+  name_template: dev-{{.Commit}}
+release:
+  draft: true


### PR DESCRIPTION
Relates to #66 

Main changes:

- Add a `.goreleaser.yml` config file.
- Configure CircleCI to only run `build` job on branches and git tags which do not match `/^[0-9]+(\.[0-9]+)*/`
- For git tags which do match `/^[0-9]+(\.[0-9]+)*/`, run `build` job (tests, etc), and then run `release` job which will publish a release to GitHub.

Minor changes:

- Switch to using stable releases of dep, instead of installing it from the master branch with `go get`.
- Move build step within `build` job to the end. Ensure tests are passing, before we even bother making sure we can build a binary.

To-Do:

- [x] Crate a `nimona-bot` user to generate OAuth token for goreleaser to use.

Sadly goreleaser needs to be a OAuth token that has grants full access to all public and private repos the user has access to.