### PR TITLE
Add peer keys

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -44,7 +44,7 @@ labels:
     color: 5319e7
   - name: "Type: Enhancement"
     color: 1d76db
-    oldname: enchancement
+    oldname: enhancement
   - name: "Type: Maintenance"
     color: fbca04
   - name: "Type: Question"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ builds:
     binary: nimona
     flags: -a
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - darwin
       - freebsd

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -210,6 +210,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "32180aa2be7cb5af5e0914688f0ff7a6ce76c0069b79a9c727ba500e942ef831"
+  inputs-digest = "db950c86c054ae7f43cda6bea7cfd54ac0864fa8f8a781dbdb6b432a7b711763"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -210,6 +210,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "db950c86c054ae7f43cda6bea7cfd54ac0864fa8f8a781dbdb6b432a7b711763"
+  inputs-digest = "32180aa2be7cb5af5e0914688f0ff7a6ce76c0069b79a9c727ba500e942ef831"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  branch = "master"
+  name = "github.com/btcsuite/btcd"
+  packages = ["btcec"]
+  revision = "675abc5df3c5531bc741b56a765e35623459da6d"
+
+[[projects]]
   name = "github.com/chzyer/readline"
   packages = ["."]
   revision = "f6d7a1f6fbf35bbf9beb80dc63c56a29dcfb759f"
@@ -23,6 +29,20 @@
   name = "github.com/emersion/go-upnp-igd"
   packages = ["."]
   revision = "6fb51d2a2a533cabb08119a9d05fe3f6b4c513f3"
+
+[[projects]]
+  name = "github.com/ethereum/go-ethereum"
+  packages = [
+    "common",
+    "common/hexutil",
+    "common/math",
+    "crypto",
+    "crypto/secp256k1",
+    "crypto/sha3",
+    "rlp"
+  ]
+  revision = "2688dab48c9b8ae71b8d95c7678817eaa17f2b53"
+  version = "v1.8.8"
 
 [[projects]]
   name = "github.com/fatih/color"
@@ -190,6 +210,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e03c55dd9311af0cf69e5a1a94f161850cb76218d97310c75eeb125ac9056caa"
+  inputs-digest = "32180aa2be7cb5af5e0914688f0ff7a6ce76c0069b79a9c727ba500e942ef831"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PACKAGES = $(shell find . -type d -not -path '*/\.*' | egrep -v 'vendor|examples
 
 $(BINARY): $(SOURCES)
 	cd cmd/${NAME} \
-		&& CGO_ENABLED=0 go build -a -o ../../${BINARY} -ldflags \ "\
+		&& go build -a -o ../../${BINARY} -ldflags \ "\
 			-s -w \
 			-X main.version=${VERSION} \
 			-X main.commit=${COMMIT} \

--- a/cmd/nimona/main.go
+++ b/cmd/nimona/main.go
@@ -258,9 +258,11 @@ func main() {
 			ps, _ := reg.GetAllPeerInfo()
 			for _, peer := range ps {
 				c.Println("* " + peer.ID)
-				c.Printf("     - public key: %x\n", peer.PublicKey)
+				c.Printf("  - public key: %x\n", peer.PublicKey)
+				c.Printf("  - signature: %x\n", peer.Signature)
+				c.Printf("  - addresses:\n")
 				for _, address := range peer.Addresses {
-					c.Printf("     - address: %s\n", address)
+					c.Printf("     - %s\n", address)
 				}
 			}
 		},
@@ -293,9 +295,11 @@ func main() {
 
 			peer := reg.GetLocalPeerInfo()
 			c.Println("* " + peer.ID)
-			c.Printf("     - public key: %x\n", peer.PublicKey)
+			c.Printf("  - public key: %x\n", peer.PublicKey)
+			c.Printf("  - signature: %x\n", peer.Signature)
+			c.Printf("  - addresses:\n")
 			for _, address := range peer.Addresses {
-				c.Printf("     - address: %s\n", address)
+				c.Printf("     - %s\n", address)
 			}
 		},
 		Help: "list protocols for local peer",

--- a/cmd/nimona/main.go
+++ b/cmd/nimona/main.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/user"
+	"path"
 	"strconv"
 	"strings"
 
@@ -34,14 +36,17 @@ var bootstrapPeerInfos = []mesh.PeerInfo{
 }
 
 func main() {
-	peerID := os.Getenv("PEER_ID")
-	if peerID == "" {
-		log.Fatal("Missing PEER_ID")
+	usr, _ := user.Current()
+	keyPath := path.Join(usr.HomeDir, ".nimona", ".key.pem")
+
+	privateKey, err := mesh.LoadOrCreatePrivateKey(keyPath)
+	if err != nil {
+		log.Fatal("could not load key", err)
 	}
 
 	port, _ := strconv.ParseInt(os.Getenv("PORT"), 10, 32)
 
-	reg := mesh.NewRegisty(peerID)
+	reg := mesh.NewRegisty(privateKey)
 	msh := mesh.New(reg)
 
 	for _, peerInfo := range bootstrapPeerInfos {

--- a/cmd/nimona/main.go
+++ b/cmd/nimona/main.go
@@ -28,7 +28,7 @@ var (
 
 var bootstrapPeerInfos = []mesh.PeerInfo{
 	mesh.PeerInfo{
-		ID: "andromeda.nimona.io",
+		ID: "0x4F63B74a46Bf61F4194022E4DD9F64d958f1663d",
 		Addresses: []string{
 			"tcp:andromeda.nimona.io:26800",
 		},
@@ -258,8 +258,9 @@ func main() {
 			ps, _ := reg.GetAllPeerInfo()
 			for _, peer := range ps {
 				c.Println("* " + peer.ID)
+				c.Printf("     - public key: %x\n", peer.PublicKey)
 				for _, address := range peer.Addresses {
-					c.Printf("     - %s\n", address)
+					c.Printf("     - address: %s\n", address)
 				}
 			}
 		},
@@ -292,8 +293,9 @@ func main() {
 
 			peer := reg.GetLocalPeerInfo()
 			c.Println("* " + peer.ID)
+			c.Printf("     - public key: %x\n", peer.PublicKey)
 			for _, address := range peer.Addresses {
-				c.Printf("     - %s\n", address)
+				c.Printf("     - address: %s\n", address)
 			}
 		},
 		Help: "list protocols for local peer",

--- a/cmd/nimona/main.go
+++ b/cmd/nimona/main.go
@@ -37,8 +37,12 @@ var bootstrapPeerInfos = []mesh.PeerInfo{
 
 func main() {
 	usr, _ := user.Current()
-	keyPath := path.Join(usr.HomeDir, ".nimona", ".key.pem")
+	configPath := path.Join(usr.HomeDir, ".nimona")
+	if err := os.MkdirAll(configPath, 0777); err != nil {
+		log.Fatal("could not create config dir", err)
+	}
 
+	keyPath := path.Join(configPath, "key")
 	privateKey, err := mesh.LoadOrCreatePrivateKey(keyPath)
 	if err != nil {
 		log.Fatal("could not load key", err)

--- a/dht/dht_test.go
+++ b/dht/dht_test.go
@@ -2,8 +2,6 @@ package dht
 
 import (
 	"context"
-	"io/ioutil"
-	"path"
 	"testing"
 
 	"github.com/nimona/go-nimona/mesh"
@@ -25,12 +23,8 @@ type dhtTestSuite struct {
 }
 
 func (suite *dhtTestSuite) SetupTest() {
-	tempDir, err := ioutil.TempDir("", "nimona")
-	suite.NoError(err)
-
-	tempFile1 := path.Join(tempDir, "key1")
-	key1, err := mesh.LoadOrCreatePrivateKey(tempFile1)
-	suite.peerID = mesh.Thumbprint(key1)
+	key1, err := mesh.CreatePrivateKey()
+	suite.peerID = mesh.IDFromPublicKey(key1.PublicKey)
 	suite.NoError(err)
 
 	suite.mockMesh = &mesh.MockMesh{}
@@ -53,12 +47,9 @@ func (suite *dhtTestSuite) TestPutSuccess() {
 	key := "a"
 	value := "b"
 	payload := messagePutValue{
-		SenderPeerInfo: mesh.PeerInfo{
-			ID:        suite.peerID,
-			Addresses: []string{},
-		},
-		Key:   "a",
-		Value: "b",
+		SenderPeerInfo: *suite.registry.GetLocalPeerInfo(),
+		Key:            "a",
+		Value:          "b",
 	}
 	to := []string{"bootstrap"}
 	suite.wire.On("Send", mock.Anything, "dht", PayloadTypePutValue, payload, to).Return(nil)

--- a/mesh/key_util.go
+++ b/mesh/key_util.go
@@ -1,0 +1,115 @@
+package mesh
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// Url-safe base64 encode that strips padding
+func base64URLEncode(data []byte) string {
+	var result = base64.URLEncoding.EncodeToString(data)
+	return strings.TrimRight(result, "=")
+}
+
+func LoadOrCreatePrivateKey(keyPath string) (*ecdsa.PrivateKey, error) {
+	var privateKey *ecdsa.PrivateKey
+
+	// Check if keyPath is empty
+	if keyPath == "" {
+		keyPath = ".key.pem"
+		log.Printf("* Using key from '%s'\n", keyPath)
+	}
+
+	// Check if the keyPath exists
+	keyExists := true
+	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+		keyExists = false
+	}
+
+	// If it exists, try to use it
+	if keyExists {
+		// load the private key
+		var errLoadingKey error
+		privateKey, errLoadingKey = loadPrivateKey(keyPath)
+		if errLoadingKey != nil {
+			return nil, errLoadingKey
+		}
+	} else {
+		log.Printf("* Key path does not exist, creating a key and storing it in '%s'\n", keyPath)
+		// generate key pair if we have not been given one
+		var errGeneratingPrivateKey error
+		privateKey, errGeneratingPrivateKey = generatePrivateKey()
+		if errGeneratingPrivateKey != nil {
+			return nil, errGeneratingPrivateKey
+		}
+	}
+
+	if keyExists == false {
+		storePrivateKey(privateKey, keyPath)
+	}
+
+	return privateKey, nil
+}
+
+func generatePrivateKey() (*ecdsa.PrivateKey, error) {
+	pubkeyCurve := elliptic.P521()                     //see http://golang.org/pkg/crypto/elliptic/#P521
+	return ecdsa.GenerateKey(pubkeyCurve, rand.Reader) // this generates a public & private key pair
+}
+
+func storePrivateKey(privateKey *ecdsa.PrivateKey, keyPath string) error {
+	// write to key path
+	ecder, errMarshalingKey := x509.MarshalECPrivateKey(privateKey)
+	if errMarshalingKey != nil {
+		return errMarshalingKey
+	}
+	// the private key, der encoded
+	// TODO Check that reading the file has no issues with the order of the blocks, eg first params, then key blocks
+	keypem, errSavingPEM := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if errSavingPEM != nil {
+		return errSavingPEM
+	}
+	pem.Encode(keypem, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ecder})
+	// the elliptic curve parameters, der encoded
+	// TODO These are hardcoded values for P256, we need to use the actual params
+	// secp256r1, errAsnMarshal := asn1.Marshal(asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7})
+	// if errAsnMarshal != nil {
+	// 	panic(errAsnMarshal)
+	// }
+	// pem.Encode(keypem, &pem.Block{Type: "EC PARAMETERS", Bytes: secp256r1})
+	return nil
+}
+
+func loadPrivateKey(keyPath string) (*ecdsa.PrivateKey, error) {
+	// read the file
+	blockBytes, errOpeningFile := ioutil.ReadFile(keyPath)
+	if errOpeningFile != nil {
+		return nil, errOpeningFile
+	}
+	// decode the der blocks
+	block, _ := pem.Decode(blockBytes)
+	privateKey, errParsingPrivateKey := x509.ParseECPrivateKey(block.Bytes)
+	if errParsingPrivateKey != nil {
+		return nil, errParsingPrivateKey
+	}
+	return privateKey, nil
+}
+
+func Thumbprint(key *ecdsa.PrivateKey) string {
+	h := sha1.New()
+	ms := ethcrypto.FromECDSAPub(key.Public())
+	h.Write(ms)
+	bs := h.Sum(nil)
+	return fmt.Sprintf("%x", bs)
+}

--- a/mesh/key_util.go
+++ b/mesh/key_util.go
@@ -2,108 +2,44 @@ package mesh
 
 import (
 	"crypto/ecdsa"
-	"crypto/sha1"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/pem"
-	"fmt"
-	"io/ioutil"
+	"errors"
 	"log"
 	"os"
-	"strings"
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
-// Url-safe base64 encode that strips padding
-func base64URLEncode(data []byte) string {
-	var result = base64.URLEncoding.EncodeToString(data)
-	return strings.TrimRight(result, "=")
-}
-
 func LoadOrCreatePrivateKey(keyPath string) (*ecdsa.PrivateKey, error) {
-	var privateKey *ecdsa.PrivateKey
-
-	// Check if keyPath is empty
 	if keyPath == "" {
-		keyPath = ".key.pem"
-		log.Printf("* Using key from '%s'\n", keyPath)
+		return nil, errors.New("missing key path")
 	}
 
-	// Check if the keyPath exists
-	keyExists := true
-	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
-		keyExists = false
+	if _, err := os.Stat(keyPath); err == nil {
+		return ethcrypto.LoadECDSA(keyPath)
 	}
 
-	// If it exists, try to use it
-	if keyExists {
-		// load the private key
-		var errLoadingKey error
-		privateKey, errLoadingKey = ethcrypto.LoadECDSA(keyPath)
-		if errLoadingKey != nil {
-			return nil, errLoadingKey
-		}
-	} else {
-		log.Printf("* Key path does not exist, creating a key and storing it in '%s'\n", keyPath)
-		// generate key pair if we have not been given one
-		var errGeneratingPrivateKey error
-		privateKey, errGeneratingPrivateKey = ethcrypto.GenerateKey()
-		if errGeneratingPrivateKey != nil {
-			return nil, errGeneratingPrivateKey
-		}
+	log.Printf("* Key path does not exist, creating new key in '%s'\n", keyPath)
+	privateKey, err := ethcrypto.GenerateKey()
+	if err != nil {
+		return nil, err
 	}
 
-	if keyExists == false {
-		ethcrypto.SaveECDSA(keyPath, privateKey)
+	if err := ethcrypto.SaveECDSA(keyPath, privateKey); err != nil {
+		return nil, err
 	}
 
 	return privateKey, nil
 }
 
-func storePrivateKey(privateKey *ecdsa.PrivateKey, keyPath string) error {
-	// write to key path
-	ecder, errMarshalingKey := x509.MarshalECPrivateKey(privateKey)
-	if errMarshalingKey != nil {
-		return errMarshalingKey
-	}
-	// the private key, der encoded
-	// TODO Check that reading the file has no issues with the order of the blocks, eg first params, then key blocks
-	keypem, errSavingPEM := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if errSavingPEM != nil {
-		return errSavingPEM
-	}
-	pem.Encode(keypem, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ecder})
-	// the elliptic curve parameters, der encoded
-	// TODO These are hardcoded values for P256, we need to use the actual params
-	// secp256r1, errAsnMarshal := asn1.Marshal(asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7})
-	// if errAsnMarshal != nil {
-	// 	panic(errAsnMarshal)
-	// }
-	// pem.Encode(keypem, &pem.Block{Type: "EC PARAMETERS", Bytes: secp256r1})
-	return nil
+func DecocdePublicKey(bs []byte) *ecdsa.PublicKey {
+	pk := ethcrypto.ToECDSAPub(bs)
+	return pk
 }
 
-func loadPrivateKey(keyPath string) (*ecdsa.PrivateKey, error) {
-	// read the file
-	blockBytes, errOpeningFile := ioutil.ReadFile(keyPath)
-	if errOpeningFile != nil {
-		return nil, errOpeningFile
-	}
-	// decode the der blocks
-	block, _ := pem.Decode(blockBytes)
-	privateKey, errParsingPrivateKey := x509.ParseECPrivateKey(block.Bytes)
-	if errParsingPrivateKey != nil {
-		return nil, errParsingPrivateKey
-	}
-	return privateKey, nil
+func EncodePublicKey(pk ecdsa.PublicKey) []byte {
+	return ethcrypto.FromECDSAPub(&pk)
 }
 
-func Thumbprint(key *ecdsa.PrivateKey) string {
-	pk := key.PublicKey
-	h := sha1.New()
-	ms := ethcrypto.FromECDSAPub(&pk)
-	h.Write(ms)
-	bs := h.Sum(nil)
-	return fmt.Sprintf("%x", bs)
+func IDFromPublicKey(pk ecdsa.PublicKey) string {
+	return ethcrypto.PubkeyToAddress(pk).String()
 }

--- a/mesh/key_util.go
+++ b/mesh/key_util.go
@@ -22,7 +22,7 @@ func LoadOrCreatePrivateKey(keyPath string) (*ecdsa.PrivateKey, error) {
 	}
 
 	log.Printf("* Key path does not exist, creating new key in '%s'\n", keyPath)
-	privateKey, err := ethcrypto.GenerateKey()
+	privateKey, err := CreatePrivateKey()
 	if err != nil {
 		return nil, err
 	}
@@ -32,6 +32,10 @@ func LoadOrCreatePrivateKey(keyPath string) (*ecdsa.PrivateKey, error) {
 	}
 
 	return privateKey, nil
+}
+
+func CreatePrivateKey() (*ecdsa.PrivateKey, error) {
+	return ethcrypto.GenerateKey()
 }
 
 func DecocdePublicKey(bs []byte) *ecdsa.PublicKey {

--- a/mesh/net.go
+++ b/mesh/net.go
@@ -36,7 +36,7 @@ func New(registry Registry) *Net {
 		reusable: map[string]*reusableConn{},
 		handlers: map[string]Handler{},
 	}
-	n.RegisterHandler("id", &ID{})
+	n.RegisterHandler("id", &ID{registry})
 	n.RegisterHandler("yamux", &Yamux{})
 	n.RegisterHandler("relay", &Relay{n})
 	return n
@@ -211,9 +211,11 @@ func (n *Net) Listen(addr string) (Listener, string, error) {
 	addresses = append(addresses, "relay:andromeda.nimona.io")
 	lock.Unlock()
 
+	// TODO replace this with something like n.registry.GetLocalPeerInfo().SetAddresses()
 	n.registry.PutLocalPeerInfo(&PeerInfo{
 		ID:        n.registry.GetLocalPeerInfo().ID,
 		Addresses: addresses,
+		PublicKey: n.registry.GetLocalPeerInfo().PublicKey,
 	})
 
 	go func() {

--- a/mesh/net.go
+++ b/mesh/net.go
@@ -212,11 +212,13 @@ func (n *Net) Listen(addr string) (Listener, string, error) {
 	lock.Unlock()
 
 	// TODO replace this with something like n.registry.GetLocalPeerInfo().SetAddresses()
-	n.registry.PutLocalPeerInfo(&PeerInfo{
+	lp := &PeerInfo{
 		ID:        n.registry.GetLocalPeerInfo().ID,
 		Addresses: addresses,
 		PublicKey: n.registry.GetLocalPeerInfo().PublicKey,
-	})
+	}
+	lp.Signature, _ = Sign(n.registry.GetPrivateKey(), lp.MarshalWithoutSignature())
+	n.registry.PutLocalPeerInfo(lp)
 
 	go func() {
 		for {

--- a/mesh/net_test.go
+++ b/mesh/net_test.go
@@ -20,12 +20,12 @@ func TestNet(t *testing.T) {
 
 	tempFile1 := path.Join(tempDir, "key1")
 	key1, err := LoadOrCreatePrivateKey(tempFile1)
-	localPeerID := Thumbprint(key1)
+	localPeerID := IDFromPublicKey(key1.PublicKey)
 	assert.NoError(t, err)
 
 	tempFile2 := path.Join(tempDir, "key2")
 	key2, err := LoadOrCreatePrivateKey(tempFile2)
-	remotePeerID := Thumbprint(key2)
+	remotePeerID := IDFromPublicKey(key2.PublicKey)
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -90,12 +90,12 @@ func TestReusableNet(t *testing.T) {
 
 	tempFile1 := path.Join(tempDir, "key1")
 	key1, err := LoadOrCreatePrivateKey(tempFile1)
-	localPeerID := Thumbprint(key1)
+	localPeerID := IDFromPublicKey(key1.PublicKey)
 	assert.NoError(t, err)
 
 	tempFile2 := path.Join(tempDir, "key2")
 	key2, err := LoadOrCreatePrivateKey(tempFile2)
-	remotePeerID := Thumbprint(key2)
+	remotePeerID := IDFromPublicKey(key2.PublicKey)
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -160,12 +160,12 @@ func TestReusableRedialNet(t *testing.T) {
 
 	tempFile1 := path.Join(tempDir, "key1")
 	key1, err := LoadOrCreatePrivateKey(tempFile1)
-	localPeerID := Thumbprint(key1)
+	localPeerID := IDFromPublicKey(key1.PublicKey)
 	assert.NoError(t, err)
 
 	tempFile2 := path.Join(tempDir, "key2")
 	key2, err := LoadOrCreatePrivateKey(tempFile2)
-	remotePeerID := Thumbprint(key2)
+	remotePeerID := IDFromPublicKey(key2.PublicKey)
 	assert.NoError(t, err)
 
 	ctx := context.Background()
@@ -244,12 +244,12 @@ func TestReusableRedialRemoteNet(t *testing.T) {
 
 	tempFile1 := path.Join(tempDir, "key1")
 	key1, err := LoadOrCreatePrivateKey(tempFile1)
-	localPeerID := Thumbprint(key1)
+	localPeerID := IDFromPublicKey(key1.PublicKey)
 	assert.NoError(t, err)
 
 	tempFile2 := path.Join(tempDir, "key2")
 	key2, err := LoadOrCreatePrivateKey(tempFile2)
-	remotePeerID := Thumbprint(key2)
+	remotePeerID := IDFromPublicKey(key2.PublicKey)
 	assert.NoError(t, err)
 
 	ctx := context.Background()

--- a/mesh/net_test.go
+++ b/mesh/net_test.go
@@ -3,9 +3,7 @@ package mesh
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"path"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,16 +13,11 @@ import (
 )
 
 func TestNet(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "nimona")
-	assert.NoError(t, err)
-
-	tempFile1 := path.Join(tempDir, "key1")
-	key1, err := LoadOrCreatePrivateKey(tempFile1)
+	key1, err := CreatePrivateKey()
 	localPeerID := IDFromPublicKey(key1.PublicKey)
 	assert.NoError(t, err)
 
-	tempFile2 := path.Join(tempDir, "key2")
-	key2, err := LoadOrCreatePrivateKey(tempFile2)
+	key2, err := CreatePrivateKey()
 	remotePeerID := IDFromPublicKey(key2.PublicKey)
 	assert.NoError(t, err)
 
@@ -85,16 +78,11 @@ func TestNet(t *testing.T) {
 }
 
 func TestReusableNet(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "nimona")
-	assert.NoError(t, err)
-
-	tempFile1 := path.Join(tempDir, "key1")
-	key1, err := LoadOrCreatePrivateKey(tempFile1)
+	key1, err := CreatePrivateKey()
 	localPeerID := IDFromPublicKey(key1.PublicKey)
 	assert.NoError(t, err)
 
-	tempFile2 := path.Join(tempDir, "key2")
-	key2, err := LoadOrCreatePrivateKey(tempFile2)
+	key2, err := CreatePrivateKey()
 	remotePeerID := IDFromPublicKey(key2.PublicKey)
 	assert.NoError(t, err)
 
@@ -155,16 +143,11 @@ func TestReusableNet(t *testing.T) {
 }
 
 func TestReusableRedialNet(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "nimona")
-	assert.NoError(t, err)
-
-	tempFile1 := path.Join(tempDir, "key1")
-	key1, err := LoadOrCreatePrivateKey(tempFile1)
+	key1, err := CreatePrivateKey()
 	localPeerID := IDFromPublicKey(key1.PublicKey)
 	assert.NoError(t, err)
 
-	tempFile2 := path.Join(tempDir, "key2")
-	key2, err := LoadOrCreatePrivateKey(tempFile2)
+	key2, err := CreatePrivateKey()
 	remotePeerID := IDFromPublicKey(key2.PublicKey)
 	assert.NoError(t, err)
 
@@ -239,16 +222,11 @@ func TestReusableRedialNet(t *testing.T) {
 }
 
 func TestReusableRedialRemoteNet(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "nimona")
-	assert.NoError(t, err)
-
-	tempFile1 := path.Join(tempDir, "key1")
-	key1, err := LoadOrCreatePrivateKey(tempFile1)
+	key1, err := CreatePrivateKey()
 	localPeerID := IDFromPublicKey(key1.PublicKey)
 	assert.NoError(t, err)
 
-	tempFile2 := path.Join(tempDir, "key2")
-	key2, err := LoadOrCreatePrivateKey(tempFile2)
+	key2, err := CreatePrivateKey()
 	remotePeerID := IDFromPublicKey(key2.PublicKey)
 	assert.NoError(t, err)
 

--- a/mesh/peerinfo.go
+++ b/mesh/peerinfo.go
@@ -1,6 +1,40 @@
 package mesh
 
+import "errors"
+
 type PeerInfo struct {
 	ID        string   `json:"id"`
 	Addresses []string `json:"addresses"`
+	PublicKey []byte   `json:"public_key"`
+}
+
+func (pi *PeerInfo) IsValid() bool {
+	pk := DecocdePublicKey(pi.PublicKey)
+	return IDFromPublicKey(*pk) == pi.ID
+}
+
+func NewPeerInfo(id string, addresses []string, publicKey []byte) (*PeerInfo, error) {
+	if id == "" {
+		return nil, errors.New("missing id")
+	}
+
+	if len(addresses) == 0 {
+		return nil, errors.New("missing addresses")
+	}
+
+	if len(publicKey) == 0 {
+		return nil, errors.New("missing public key")
+	}
+
+	pi := &PeerInfo{
+		ID:        id,
+		Addresses: addresses,
+		PublicKey: publicKey,
+	}
+
+	if !pi.IsValid() {
+		return nil, errors.New("id and pk don't match")
+	}
+
+	return pi, nil
 }

--- a/mesh/registry.go
+++ b/mesh/registry.go
@@ -1,6 +1,7 @@
 package mesh
 
 import (
+	"crypto/ecdsa"
 	"errors"
 	"sync"
 	"time"
@@ -27,7 +28,8 @@ type Registry interface {
 	// Discover(ctx context.Context, peerID, protocol string) ([]net.Address, error)
 }
 
-func NewRegisty(peerID string) Registry {
+func NewRegisty(key *ecdsa.PrivateKey) Registry {
+	peerID := Thumbprint(key)
 	reg := &registry{
 		localPeer: &PeerInfo{
 			ID:        peerID,

--- a/mesh/registry.go
+++ b/mesh/registry.go
@@ -29,11 +29,12 @@ type Registry interface {
 }
 
 func NewRegisty(key *ecdsa.PrivateKey) Registry {
-	peerID := Thumbprint(key)
+	peerID := IDFromPublicKey(key.PublicKey)
 	reg := &registry{
 		localPeer: &PeerInfo{
 			ID:        peerID,
 			Addresses: []string{},
+			PublicKey: EncodePublicKey(key.PublicKey),
 		},
 		peers: map[string]*PeerInfo{},
 	}

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -26,7 +26,7 @@ var messagingProtocolVersionCanon = semver.New(messagingProtocolVersion)
 type Wire interface {
 	mesh.Handler
 	HandleExtensionEvents(extension string, h EventHandler) error
-	Send(ctx context.Context, extention, payloadType string, payload interface{}, to []string) error
+	Send(ctx context.Context, extension, payloadType string, payload interface{}, to []string) error
 }
 
 type wire struct {
@@ -84,7 +84,7 @@ func (m *wire) Process(bs []byte) error {
 	hn, ok := m.handlers[msg.Extension]
 	if !ok {
 		m.logger.Info(
-			"No handler registered for extention",
+			"No handler registered for extension",
 			zap.String("extension", msg.Extension),
 		)
 		return errors.New("no handler")
@@ -113,7 +113,7 @@ func (m *wire) Process(bs []byte) error {
 	return nil
 }
 
-func (m *wire) Send(ctx context.Context, extention, payloadType string, payload interface{}, to []string) error {
+func (m *wire) Send(ctx context.Context, extension, payloadType string, payload interface{}, to []string) error {
 	if len(to) == 0 {
 		return nil
 	}
@@ -125,7 +125,7 @@ func (m *wire) Send(ctx context.Context, extention, payloadType string, payload 
 		msg := &messageOut{
 			Version:     *messagingProtocolVersionCanon,
 			Codec:       messagingProtocolCodecJSON,
-			Extension:   extention,
+			Extension:   extension,
 			PayloadType: payloadType,
 			Payload:     payload,
 			From:        m.registry.GetLocalPeerInfo().ID,

--- a/wire/wire_mock.go
+++ b/wire/wire_mock.go
@@ -70,13 +70,13 @@ func (_m *MockWire) Initiate(_a0 net.Conn) (net.Conn, error) {
 	return r0, r1
 }
 
-// Send provides a mock function with given fields: ctx, extention, payloadType, payload, to
-func (_m *MockWire) Send(ctx context.Context, extention string, payloadType string, payload interface{}, to []string) error {
-	ret := _m.Called(ctx, extention, payloadType, payload, to)
+// Send provides a mock function with given fields: ctx, extension, payloadType, payload, to
+func (_m *MockWire) Send(ctx context.Context, extension string, payloadType string, payload interface{}, to []string) error {
+	ret := _m.Called(ctx, extension, payloadType, payload, to)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, interface{}, []string) error); ok {
-		r0 = rf(ctx, extention, payloadType, payload, to)
+		r0 = rf(ctx, extension, payloadType, payload, to)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
### Notes

* From this point on arbitrary peer ids are being discouraged
* Each peer generates its own ecdsa key and uses that to identify itself and sign messages
* Peer ID is generated using the ethereum address generation spec that uses keccak-256 and butchers the resulting hash

### Changelog

* Registry now requires a private/public key pair and defers local peer id from the public part
* Peer Info now includes the peer's public key which should match the peer's ID
* Peer Info also includes a signature for the SHA1 of the JSON encoded Peer Info (without the signature attribute)
* In the ID wrapper, both sides now send their full signed peer info and validates remote peer info before allowing connection
* In the DHT, the sender peer info attribute now includes the full signed peer info


### Future work

* Consider replacing peer id generation to something saner/simpler than ethereum address generation (#82)
* Remove ethereum crypto dep with something that uses golang native crypto as it will probably make porting to android/ios easier (#83)
* Introduce standard way for signing structures with optional codecs and hashing (#84)
* Merge token read/write functions into wire (#85)
* Registry should by default only add valid peer infos, but have an option to add "unsafe" ones for when the public key or signature is not known (might be useful for bootstraping) (#86)
* ID Wrapper should challenge remote peer's id before accepting connection (#87)