### PR TITLE
Daemon install

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:4e575774903bfe2f3c06bae7c153dd548ac34167956cfb63959906e31b3e0592"
+  name = "github.com/digitalocean/godo"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d29fc3d82041712620b923e8330eddb8a364840b"
+  version = "v1.6.0"
+
+[[projects]]
   branch = "master"
   digest = "1:73ce7cd73bf041d37aa6ffc540ff1c27f0e443b4db269bd0204649358c73a193"
   name = "github.com/emersion/go-upnp-igd"
@@ -48,14 +56,6 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae"
-
-[[projects]]
-  branch = "master"
-  digest = "1:2b0df69b0d482719446858d567d12f4565d1908ff563db27250cb2cde7f461ec"
-  name = "github.com/gin-contrib/static"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "8cbcdde04781ade853025b0ff7001aaf0ed06150"
 
 [[projects]]
   digest = "1:d5083934eb25e45d17f72ffa86cae3814f4a9d6c073c4f16b64147169b245606"
@@ -102,6 +102,14 @@
   pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
+
+[[projects]]
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  pruneopts = "UT"
+  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:7b5c6e2eeaa9ae5907c391a91c132abfd5c9e8a784a341b5625e750c67e6825d"
@@ -342,6 +350,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:595e123593925253dd02152777ddb8cd42300c4f61e783e163b053802547c47c"
+  name = "github.com/tent/http-link-go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ac974c61c2f990f4115b119354b5e0b47550e888"
+
+[[projects]]
+  branch = "master"
   digest = "1:ba321cf9a010d56190c186289ef67280f7a86d3175d66ac4502a104e1f458f2b"
   name = "github.com/ugorji/go"
   packages = ["codec"]
@@ -389,14 +405,27 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a412caf33b5d3c7938c28e1e745c10664bd180277b73ab3b34c0c467886f9969"
+  digest = "1:33b9d71d1dde2106309484a388eb7ba53cd1f67014e34a71f7b3dbc20bd186e5"
   name = "golang.org/x/net"
   packages = [
+    "context",
+    "context/ctxhttp",
     "idna",
     "publicsuffix",
   ]
   pruneopts = "UT"
   revision = "49bb7cea24b1df9410e1712aa6433dae904ff66a"
+
+[[projects]]
+  branch = "master"
+  digest = "1:1bce229fad01cbad9bd00e70ca32afff25ac2cea3dd710d50f88c967c1c3df65"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = "UT"
+  revision = "9dcd33a902f40452422c2367fefcb95b54f9f8f8"
 
 [[projects]]
   branch = "master"
@@ -430,6 +459,22 @@
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:6247f76e55a1e1a5c19a81e2d4b4dff6730461eeb5bbb0a16dd4a8ec8637ee93"
+  name = "google.golang.org/appengine"
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = "UT"
+  revision = "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06"
+  version = "v1.2.0"
+
+[[projects]]
   digest = "1:cbc72c4c4886a918d6ab4b95e347ffe259846260f99ebdd8a198c2331cf2b2e9"
   name = "gopkg.in/go-playground/validator.v8"
   packages = ["."]
@@ -458,10 +503,10 @@
   analyzer-version = 1
   input-imports = [
     "github.com/davecgh/go-spew/spew",
+    "github.com/digitalocean/godo",
     "github.com/emersion/go-upnp-igd",
     "github.com/fatih/structs",
     "github.com/gin-contrib/cors",
-    "github.com/gin-contrib/static",
     "github.com/gin-gonic/gin",
     "github.com/gin-gonic/gin/render",
     "github.com/go-resty/resty",
@@ -483,6 +528,7 @@
     "go.uber.org/zap",
     "go.uber.org/zap/zapcore",
     "golang.org/x/crypto/sha3",
+    "golang.org/x/oauth2",
     "gopkg.in/inconshreveable/go-keen.v0",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,10 +53,6 @@
   name = "go.uber.org/zap"
   version = "1.8.0"
 
-[[constraint]]
-  name = "gopkg.in/abiosoft/ishell.v2"
-  version = "2.0.0"
-
 [prune]
   go-tests = true
   unused-packages = true

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For a technical overview, please refer to the [documentation introduction](https
 
 ## Development
 
-### Installation
+### Installation from Source
 
 Assuming you have a working [Go environment] with Go 1.10 or higher:
 
@@ -27,6 +27,24 @@ dep ensure
 
 You can either `go install nimona.io/go/cmd/nimona` or run it from 
 source every time with `go run nimona.io/go/cmd/nimona`.
+
+### Installation in Provider
+
+You can install the daemon in a supported provider.
+```
+nimona daemon install --platform do --token <> --ssh-fingerprint <> --hostname <>
+```
+
+#### Supported Flags
+* **--platform** the provider to be used for the deployment
+* **--hostname** the hostname that nimona will use, if defined the dns will also be updated
+* **--token** the access token required to authenticate with the provider
+* **--ssh-fingerprint** the ssh fingerprint for the key that will be added to the server (needs to exist in the provider)
+* **--size** size of the server, default for DO *s-1vcpu-1gb*
+* **--region** region that the server will be deployed, default *lon1*
+
+#### Suppored Providers
+* do - DigitalOcean
 
 #### Commands
 

--- a/cmd/nimona/cmd/daemon.go
+++ b/cmd/nimona/cmd/daemon.go
@@ -1,138 +1,19 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
-	"os"
-	"os/user"
-	"path"
-
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-
-	"nimona.io/go/api"
-	"nimona.io/go/dht"
-	"nimona.io/go/net"
-	"nimona.io/go/peers"
-	"nimona.io/go/storage"
-	"nimona.io/go/telemetry"
 )
 
-var (
-	daemonConfigPath     string
-	daemonPort           int
-	daemonAPIPort        int
-	daemonEnableRelaying bool
-	daemonEnableMetrics  bool
-
-	bootstrapAddresses = []string{
-		"tcp:andromeda.nimona.io:21013",
-		// "tcp:borealis.nimona.io:21013",
-		// "tcp:cassiopeia.nimona.io:21013",
-		// "tcp:draco.nimona.io:21013",
-		// "tcp:eridanus.nimona.io:21013",
-		// "tcp:fornax.nimona.io:21013",
-		// "tcp:gemini.nimona.io:21013",
-		// "tcp:hydra.nimona.io:21013",
-		// "tcp:indus.nimona.io:21013",
-		// "tcp:lacerta.nimona.io:21013",
-		// "tcp:mensa.nimona.io:21013",
-		// "tcp:norma.nimona.io:21013",
-		// "tcp:orion.nimona.io:21013",
-		// "tcp:pyxis.nimona.io:21013",
-		// "tcp:stats.nimona.io:21013",
-	}
-)
-
-// daemonCmd represents the daemon command
-var daemonCmd = &cobra.Command{
-	Use:   "daemon",
-	Short: "Start a peer as a daemon",
-	Long:  "",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if daemonConfigPath == "" {
-			usr, _ := user.Current()
-			daemonConfigPath = path.Join(usr.HomeDir, ".nimona")
-		}
-
-		if err := os.MkdirAll(daemonConfigPath, 0777); err != nil {
-			return errors.Wrap(err, "could not create config dir")
-		}
-
-		addressBook, err := peers.NewAddressBook(daemonConfigPath)
-		if err != nil {
-			return errors.Wrap(err, "could not load key")
-		}
-
-		addressBook.LocalHostname = announceHostname
-
-		if daemonEnableRelaying {
-			addressBook.AddLocalPeerRelay(bootstrapAddresses...)
-		}
-
-		storagePath := path.Join(daemonConfigPath, "storage")
-		dpr := storage.NewDiskStorage(storagePath)
-		n, _ := net.NewExchange(addressBook, dpr, fmt.Sprintf("0.0.0.0:%d", daemonPort))
-		dht, _ := dht.NewDHT(n, addressBook, bootstrapAddresses)
-		telemetry.NewTelemetry(n, addressBook.GetLocalPeerKey(), "tcp:stats.nimona.io:21013")
-
-		n.RegisterDiscoverer(dht)
-
-		peerAddress := fmt.Sprintf("0.0.0.0:%d", daemonAPIPort)
-		apiAddress := fmt.Sprintf("http://localhost:%d", daemonAPIPort)
-
-		log.Println("Started daemon.")
-		log.Println("* Peer key:", addressBook.GetLocalPeerInfo().Thumbprint())
-		peerAddresses := addressBook.GetLocalPeerAddresses()
-		if len(peerAddresses) > 0 {
-			log.Println("* Peer addresses:")
-			for _, addr := range addressBook.GetLocalPeerAddresses() {
-				log.Println("  *", addr)
-			}
-		}
-		log.Println("* HTTP API address:", apiAddress)
-
-		api := api.New(addressBook, dht, n, dpr)
-		err = api.Serve(peerAddress)
-		return errors.Wrap(err, "http server stopped")
+// daemon represents the daemon command
+var daemon = &cobra.Command{
+	Use: "daemon",
+	Aliases: []string{
+		"daemons",
 	},
+	Short: "Daemon commands",
+	Long:  "",
 }
 
 func init() {
-	rootCmd.AddCommand(daemonCmd)
-
-	daemonCmd.PersistentFlags().IntVar(
-		&daemonPort,
-		"port",
-		0,
-		"peer port",
-	)
-
-	daemonCmd.PersistentFlags().IntVar(
-		&daemonAPIPort,
-		"api-port",
-		8030,
-		"api port",
-	)
-
-	daemonCmd.PersistentFlags().BoolVar(
-		&daemonEnableRelaying,
-		"relay",
-		true,
-		"enable relaying through bootstrap peers",
-	)
-
-	daemonCmd.PersistentFlags().BoolVar(
-		&daemonEnableMetrics,
-		"metrics",
-		false,
-		"enable sending anonymous metrics",
-	)
-
-	daemonCmd.PersistentFlags().StringSliceVar(
-		&bootstrapAddresses,
-		"bootstraps",
-		bootstrapAddresses,
-		"bootstrap addresses",
-	)
+	rootCmd.AddCommand(daemon)
 }

--- a/cmd/nimona/cmd/daemonInstall.go
+++ b/cmd/nimona/cmd/daemonInstall.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 
 	"github.com/spf13/cobra"
@@ -34,11 +35,24 @@ var daemonInstallCmd = &cobra.Command{
 				return err
 			}
 
+			cmd.Printf("Starting server: %s\n", hostname)
+
 			ip, err := dop.NewInstance(hostname, sshFingerprint, size, region)
 			if err != nil {
 				return err
 			}
+
 			cmd.Printf("Server created. IP: %s\n", ip)
+
+			cmd.Printf("Updating domain: %s with ip: %s\n", hostname, ip)
+
+			err = dop.UpdateDomain(context.Background(),
+				hostname, ip)
+			if err != nil {
+				return err
+			}
+			cmd.Println("Domain updated")
+
 		case "":
 			return ErrNoPlatform
 		}

--- a/cmd/nimona/cmd/daemonInstall.go
+++ b/cmd/nimona/cmd/daemonInstall.go
@@ -44,6 +44,11 @@ var daemonInstallCmd = &cobra.Command{
 
 			cmd.Printf("Server created. IP: %s\n", ip)
 
+			// If hostname specified create domain entry
+			if hostname == "" {
+				return nil
+			}
+
 			cmd.Printf("Updating domain: %s with ip: %s\n", hostname, ip)
 
 			err = dop.UpdateDomain(context.Background(),

--- a/cmd/nimona/cmd/daemonInstall.go
+++ b/cmd/nimona/cmd/daemonInstall.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"nimona.io/go/cmd/nimona/cmd/providers"
+)
+
+var (
+	platform       string
+	hostname       string
+	token          string
+	sshFingerprint string
+)
+
+// daemonInstallCmd represents the daemon command
+var daemonInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install a peer as a daemon in a remote provider",
+	Long:  "",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if platform == "" {
+			return errors.New("no platform defined")
+		}
+		if token == "" {
+			return errors.New("missing platform token")
+		}
+
+		dop := providers.NewDigitalocean(token)
+
+		dop.NewInstance("test")
+
+		return nil
+	},
+}
+
+func init() {
+	daemon.AddCommand(daemonInstallCmd)
+
+	daemonInstallCmd.PersistentFlags().StringVar(
+		&platform,
+		"platform",
+		"",
+		"target platform",
+	)
+	daemonInstallCmd.PersistentFlags().StringVar(
+		&hostname,
+		"hostname",
+		"",
+		"peer hostname",
+	)
+	daemonInstallCmd.PersistentFlags().StringVar(
+		&token,
+		"token",
+		"",
+		"platform access token",
+	)
+	daemonInstallCmd.PersistentFlags().StringVar(
+		&sshFingerprint,
+		"sshFingerprint",
+		"",
+		"sshFingerprint",
+	)
+}

--- a/cmd/nimona/cmd/daeomonStart.go
+++ b/cmd/nimona/cmd/daeomonStart.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"path"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"nimona.io/go/api"
+	"nimona.io/go/dht"
+	"nimona.io/go/net"
+	"nimona.io/go/peers"
+	"nimona.io/go/storage"
+	"nimona.io/go/telemetry"
+)
+
+var (
+	daemonConfigPath     string
+	daemonPort           int
+	daemonAPIPort        int
+	daemonEnableRelaying bool
+	daemonEnableMetrics  bool
+
+	bootstrapAddresses = []string{
+		"tcp:andromeda.nimona.io:21013",
+		// "tcp:borealis.nimona.io:21013",
+		// "tcp:cassiopeia.nimona.io:21013",
+		// "tcp:draco.nimona.io:21013",
+		// "tcp:eridanus.nimona.io:21013",
+		// "tcp:fornax.nimona.io:21013",
+		// "tcp:gemini.nimona.io:21013",
+		// "tcp:hydra.nimona.io:21013",
+		// "tcp:indus.nimona.io:21013",
+		// "tcp:lacerta.nimona.io:21013",
+		// "tcp:mensa.nimona.io:21013",
+		// "tcp:norma.nimona.io:21013",
+		// "tcp:orion.nimona.io:21013",
+		// "tcp:pyxis.nimona.io:21013",
+		// "tcp:stats.nimona.io:21013",
+	}
+)
+
+// daemonStartCmd represents the daemon command
+var daemonStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start a peer as a daemon",
+	Long:  "",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if daemonConfigPath == "" {
+			usr, _ := user.Current()
+			daemonConfigPath = path.Join(usr.HomeDir, ".nimona")
+		}
+
+		if err := os.MkdirAll(daemonConfigPath, 0777); err != nil {
+			return errors.Wrap(err, "could not create config dir")
+		}
+
+		addressBook, err := peers.NewAddressBook(daemonConfigPath)
+		if err != nil {
+			return errors.Wrap(err, "could not load key")
+		}
+
+		addressBook.LocalHostname = announceHostname
+
+		if daemonEnableRelaying {
+			addressBook.AddLocalPeerRelay(bootstrapAddresses...)
+		}
+
+		storagePath := path.Join(daemonConfigPath, "storage")
+		dpr := storage.NewDiskStorage(storagePath)
+		n, _ := net.NewExchange(addressBook, dpr, fmt.Sprintf("0.0.0.0:%d", daemonPort))
+		dht, _ := dht.NewDHT(n, addressBook, bootstrapAddresses)
+		telemetry.NewTelemetry(n, addressBook.GetLocalPeerKey(), "tcp:stats.nimona.io:21013")
+
+		n.RegisterDiscoverer(dht)
+
+		peerAddress := fmt.Sprintf("0.0.0.0:%d", daemonAPIPort)
+		apiAddress := fmt.Sprintf("http://localhost:%d", daemonAPIPort)
+
+		log.Println("Started daemon.")
+		log.Println("* Peer key:", addressBook.GetLocalPeerInfo().Thumbprint())
+		peerAddresses := addressBook.GetLocalPeerAddresses()
+		if len(peerAddresses) > 0 {
+			log.Println("* Peer addresses:")
+			for _, addr := range addressBook.GetLocalPeerAddresses() {
+				log.Println("  *", addr)
+			}
+		}
+		log.Println("* HTTP API address:", apiAddress)
+
+		api := api.New(addressBook, dht, n, dpr)
+		err = api.Serve(peerAddress)
+		return errors.Wrap(err, "http server stopped")
+	},
+}
+
+func init() {
+	daemon.AddCommand(daemonStartCmd)
+
+	daemonStartCmd.PersistentFlags().IntVar(
+		&daemonPort,
+		"port",
+		0,
+		"peer port",
+	)
+
+	daemonStartCmd.PersistentFlags().IntVar(
+		&daemonAPIPort,
+		"api-port",
+		8030,
+		"api port",
+	)
+
+	daemonStartCmd.PersistentFlags().BoolVar(
+		&daemonEnableRelaying,
+		"relay",
+		true,
+		"enable relaying through bootstrap peers",
+	)
+
+	daemonStartCmd.PersistentFlags().BoolVar(
+		&daemonEnableMetrics,
+		"metrics",
+		false,
+		"enable sending anonymous metrics",
+	)
+
+	daemonStartCmd.PersistentFlags().StringSliceVar(
+		&bootstrapAddresses,
+		"bootstraps",
+		bootstrapAddresses,
+		"bootstrap addresses",
+	)
+}

--- a/cmd/nimona/cmd/providers/provider.go
+++ b/cmd/nimona/cmd/providers/provider.go
@@ -1,0 +1,7 @@
+package providers
+
+// Provider is any system that nimona can be deployed, remote or local
+type Provider interface {
+	// NewInstance creates a new server
+	NewInstance(name string) error
+}

--- a/cmd/nimona/cmd/providers/provider.go
+++ b/cmd/nimona/cmd/providers/provider.go
@@ -1,7 +1,15 @@
 package providers
 
+import "errors"
+
+var (
+	// ErrNoToken returned when no token has beed provided
+	ErrNoToken = errors.New("missing token")
+)
+
 // Provider is any system that nimona can be deployed, remote or local
 type Provider interface {
 	// NewInstance creates a new server
-	NewInstance(name string) error
+	NewInstance(name, sshFingerprint, size, region string) (ip string,
+		err error)
 }

--- a/cmd/nimona/cmd/providers/provider.go
+++ b/cmd/nimona/cmd/providers/provider.go
@@ -1,6 +1,9 @@
 package providers
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 var (
 	// ErrNoToken returned when no token has beed provided
@@ -12,4 +15,5 @@ type Provider interface {
 	// NewInstance creates a new server
 	NewInstance(name, sshFingerprint, size, region string) (ip string,
 		err error)
+	UpdateDomain(ctx context.Context, name, ip string) error
 }

--- a/cmd/nimona/cmd/providers/provider_digitalocean.go
+++ b/cmd/nimona/cmd/providers/provider_digitalocean.go
@@ -95,8 +95,9 @@ func (dp *DigitalOceanProvider) NewInstance(name, sshFingerprint,
 	userData := fmt.Sprintf(cloudInit, "")
 	if name != "" {
 		userData = fmt.Sprintf(cloudInit, "--announce-hostname="+name)
+	} else {
+		name = fmt.Sprintf("nimona-%d", time.Now().Unix())
 	}
-
 	ctx := context.Background()
 	createRequest := &godo.DropletCreateRequest{
 		Name:   name,

--- a/cmd/nimona/cmd/providers/provider_digitalocean.go
+++ b/cmd/nimona/cmd/providers/provider_digitalocean.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/digitalocean/godo"
@@ -29,7 +30,7 @@ const (
           ExecStartPre=-/usr/bin/docker stop nimona
           ExecStartPre=-/usr/bin/docker rm nimona
           ExecStartPre=/usr/bin/docker pull nimona/nimona:latest
-          ExecStart=/usr/bin/docker run --name nimona --rm -p 21013:21013 nimona/nimona daemon --port=21013 --api-port=8080
+          ExecStart=/usr/bin/docker run --name nimona --rm -p 21013:21013 nimona/nimona daemon --port=21013 --api-port=8080 --announce-hostname=%s
           
           [Install]
           WantedBy=multi-user.target`
@@ -91,7 +92,7 @@ func (dp *DigitalOceanProvider) NewInstance(name, sshFingerprint,
 		SSHKeys: []godo.DropletCreateSSHKey{godo.DropletCreateSSHKey{
 			Fingerprint: sshFingerprint,
 		}},
-		UserData: cloudInit,
+		UserData: fmt.Sprintf(cloudInit, name),
 	}
 
 	// Create server

--- a/cmd/nimona/cmd/providers/provider_digitalocean.go
+++ b/cmd/nimona/cmd/providers/provider_digitalocean.go
@@ -32,7 +32,7 @@ const (
           ExecStartPre=-/usr/bin/docker stop nimona
           ExecStartPre=-/usr/bin/docker rm nimona
           ExecStartPre=/usr/bin/docker pull nimona/nimona:latest
-          ExecStart=/usr/bin/docker run --name nimona --rm -p 21013:21013 nimona/nimona daemon --port=21013 --api-port=8080 %s
+          ExecStart=/usr/bin/docker run --name nimona --rm -p 21013:21013  -p 8080:8080 nimona/nimona daemon --port=21013 --api-port=8080 %s
           
           [Install]
           WantedBy=multi-user.target`

--- a/cmd/nimona/cmd/providers/provider_digitalocean.go
+++ b/cmd/nimona/cmd/providers/provider_digitalocean.go
@@ -198,8 +198,6 @@ func (dp *DigitalOceanProvider) UpdateDomain(ctx context.Context,
 		}
 	}
 
-	fmt.Println(fullPathFound)
-
 	if !fullPathFound {
 		_, _, err := dp.client.Domains.CreateRecord(ctx, userDomain,
 			&godo.DomainRecordEditRequest{

--- a/cmd/nimona/cmd/providers/provider_digitalocean.go
+++ b/cmd/nimona/cmd/providers/provider_digitalocean.go
@@ -1,0 +1,66 @@
+package providers
+
+import (
+	"context"
+	"log"
+
+	"github.com/digitalocean/godo"
+	"golang.org/x/oauth2"
+)
+
+type DigitalOceanProvider struct {
+	client *godo.Client
+}
+
+type TokenSource struct {
+	AccessToken string
+}
+
+func (t *TokenSource) Token() (*oauth2.Token, error) {
+	token := &oauth2.Token{
+		AccessToken: t.AccessToken,
+	}
+	return token, nil
+}
+
+func NewDigitalocean(token string) Provider {
+	tokenSource := &TokenSource{
+		AccessToken: token,
+	}
+
+	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
+	client := godo.NewClient(oauthClient)
+
+	return &DigitalOceanProvider{
+		client: client,
+	}
+}
+
+func (dp *DigitalOceanProvider) NewInstance(name string) error {
+
+	createRequest := &godo.DropletCreateRequest{
+		Name:   name,
+		Region: "lon1",
+		Size:   "s-1vcpu-1gb",
+		Image: godo.DropletCreateImage{
+			Slug: "coreos-stable",
+		},
+		SSHKeys: []godo.DropletCreateSSHKey{godo.DropletCreateSSHKey{}},
+	}
+
+	drop, resp, err := dp.client.Droplets.Create(
+		context.Background(), createRequest)
+	if err != nil {
+		log.Println(err)
+		// return err
+	}
+
+	// list, resp, _ := dp.client.Images.List(context.Background(), &godo.ListOptions{
+	// 	PerPage: 1000,
+	// })
+
+	log.Printf("%+v\n", drop)
+	log.Printf("%+v\n", resp)
+
+	return nil
+}

--- a/cmd/nimona/cmd/providers/provider_digitalocean.go
+++ b/cmd/nimona/cmd/providers/provider_digitalocean.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -51,6 +52,13 @@ func (t *tokenSource) Token() (*oauth2.Token, error) {
 	}
 	return token, nil
 }
+
+var (
+	// ErrNewinstanceTimeout is returned when NewInstances times out
+	// while waiting for the instance to start
+	ErrNewinstanceTimeout = errors.New(
+		"timeout while waiting for new instance, please check manually")
+)
 
 // NewDigitalocean creates a new DigitalOcean Provider
 func NewDigitalocean(token string) (Provider, error) {
@@ -125,7 +133,7 @@ func (dp *DigitalOceanProvider) NewInstance(name, sshFingerprint,
 
 		wn++
 		time.Sleep(2 * time.Second)
-
 	}
 
+	return "", ErrNewinstanceTimeout
 }

--- a/cmd/nimona/cmd/providers/provider_digitalocean.go
+++ b/cmd/nimona/cmd/providers/provider_digitalocean.go
@@ -24,7 +24,6 @@ const (
           Description=nimona
           After=docker.service
           Requires=docker.service
-          After=docker.redis.service
           
           [Service]
           TimeoutStartSec=0

--- a/cmd/nimona/cmd/providers/provider_digitalocean.go
+++ b/cmd/nimona/cmd/providers/provider_digitalocean.go
@@ -31,7 +31,7 @@ const (
           ExecStartPre=-/usr/bin/docker stop nimona
           ExecStartPre=-/usr/bin/docker rm nimona
           ExecStartPre=/usr/bin/docker pull nimona/nimona:latest
-          ExecStart=/usr/bin/docker run --name nimona --rm -p 21013:21013 nimona/nimona daemon --port=21013 --api-port=8080 --announce-hostname=%s
+          ExecStart=/usr/bin/docker run --name nimona --rm -p 21013:21013 nimona/nimona daemon --port=21013 --api-port=8080 %s
           
           [Install]
           WantedBy=multi-user.target`
@@ -89,6 +89,11 @@ func (dp *DigitalOceanProvider) NewInstance(name, sshFingerprint,
 		region = "lon1"
 	}
 
+	userData := fmt.Sprintf(cloudInit, "")
+	if name != "" {
+		userData = fmt.Sprintf(cloudInit, "--announce-hostname="+name)
+	}
+
 	ctx := context.Background()
 	createRequest := &godo.DropletCreateRequest{
 		Name:   name,
@@ -100,7 +105,7 @@ func (dp *DigitalOceanProvider) NewInstance(name, sshFingerprint,
 		SSHKeys: []godo.DropletCreateSSHKey{godo.DropletCreateSSHKey{
 			Fingerprint: sshFingerprint,
 		}},
-		UserData: fmt.Sprintf(cloudInit, name),
+		UserData: userData,
 	}
 
 	// Create server

--- a/cmd/nimona/cmd/providers/provider_digitalocean.go
+++ b/cmd/nimona/cmd/providers/provider_digitalocean.go
@@ -2,29 +2,62 @@ package providers
 
 import (
 	"context"
-	"log"
+	"time"
 
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
 )
 
+const (
+	cloudInit = `#cloud-config
+
+  coreos:
+    units:
+      - name: nimona.service
+        command: start
+        enable: true
+        content: |
+          [Unit]
+          Description=nimona
+          After=docker.service
+          Requires=docker.service
+          After=docker.redis.service
+          
+          [Service]
+          TimeoutStartSec=0
+          Restart=always
+          ExecStartPre=-/usr/bin/docker stop nimona
+          ExecStartPre=-/usr/bin/docker rm nimona
+          ExecStartPre=/usr/bin/docker pull nimona/nimona:latest
+          ExecStart=/usr/bin/docker run --name nimona --rm -p 21013:21013 nimona/nimona daemon --port=21013 --api-port=8080
+          
+          [Install]
+          WantedBy=multi-user.target`
+)
+
+// DigitalOceanProvider prodides a DO operations
 type DigitalOceanProvider struct {
 	client *godo.Client
 }
 
-type TokenSource struct {
+type tokenSource struct {
 	AccessToken string
 }
 
-func (t *TokenSource) Token() (*oauth2.Token, error) {
+func (t *tokenSource) Token() (*oauth2.Token, error) {
 	token := &oauth2.Token{
 		AccessToken: t.AccessToken,
 	}
 	return token, nil
 }
 
-func NewDigitalocean(token string) Provider {
-	tokenSource := &TokenSource{
+// NewDigitalocean creates a new DigitalOcean Provider
+func NewDigitalocean(token string) (Provider, error) {
+	if token == "" {
+		return nil, ErrNoToken
+	}
+
+	tokenSource := &tokenSource{
 		AccessToken: token,
 	}
 
@@ -33,34 +66,57 @@ func NewDigitalocean(token string) Provider {
 
 	return &DigitalOceanProvider{
 		client: client,
-	}
+	}, nil
 }
 
-func (dp *DigitalOceanProvider) NewInstance(name string) error {
+// NewInstance creates a new DO Droplet
+func (dp *DigitalOceanProvider) NewInstance(name, sshFingerprint,
+	size, region string) (string, error) {
+	if size == "" {
+		size = "s-1vcpu-1gb"
+	}
 
+	if region == "" {
+		region = "lon1"
+	}
+
+	ctx := context.Background()
 	createRequest := &godo.DropletCreateRequest{
 		Name:   name,
-		Region: "lon1",
-		Size:   "s-1vcpu-1gb",
+		Region: region,
+		Size:   size,
 		Image: godo.DropletCreateImage{
 			Slug: "coreos-stable",
 		},
-		SSHKeys: []godo.DropletCreateSSHKey{godo.DropletCreateSSHKey{}},
+		SSHKeys: []godo.DropletCreateSSHKey{godo.DropletCreateSSHKey{
+			Fingerprint: sshFingerprint,
+		}},
+		UserData: cloudInit,
 	}
 
-	drop, resp, err := dp.client.Droplets.Create(
-		context.Background(), createRequest)
+	// Create server
+	drop, _, err := dp.client.Droplets.Create(
+		ctx, createRequest)
 	if err != nil {
-		log.Println(err)
-		// return err
+		return "", err
 	}
 
-	// list, resp, _ := dp.client.Images.List(context.Background(), &godo.ListOptions{
-	// 	PerPage: 1000,
-	// })
+	// Wait for the API to return an IP
+	for {
+		d, _, err := dp.client.Droplets.Get(ctx, drop.ID)
+		if err != nil {
+			return "", err
+		}
 
-	log.Printf("%+v\n", drop)
-	log.Printf("%+v\n", resp)
+		ip, err := d.PublicIPv4()
+		if err != nil {
+			return "", err
+		}
+		if ip != "" {
+			return ip, nil
+		}
 
-	return nil
+		time.Sleep(2 * time.Second)
+	}
+
 }

--- a/cmd/nimona/cmd/providers/provider_digitalocean.go
+++ b/cmd/nimona/cmd/providers/provider_digitalocean.go
@@ -101,6 +101,8 @@ func (dp *DigitalOceanProvider) NewInstance(name, sshFingerprint,
 		return "", err
 	}
 
+	wn := 0
+
 	// Wait for the API to return an IP
 	for {
 		d, _, err := dp.client.Droplets.Get(ctx, drop.ID)
@@ -116,7 +118,13 @@ func (dp *DigitalOceanProvider) NewInstance(name, sshFingerprint,
 			return ip, nil
 		}
 
+		if wn == 60 {
+			break
+		}
+
+		wn++
 		time.Sleep(2 * time.Second)
+
 	}
 
 }


### PR DESCRIPTION
Adds the ability to create a server in DigitalOcean and run nimona in a container. Closes #163 

---

* [x] Move `nimona daemon` to `nimona daemon start`
* [x] Add `nimona daemon install` to allow setting up daemons on cloud providers
* [x] Add Digital Ocean platform for `daemon install`
  * [x] Add `--platform=do` for `daemon install` to create a droplet with the latest nimona container
    * [x] Docker must be able to recover on termination
    * [x] Docker must be able to auto start on droplet boot
    * [x] Docker must be able to expose both ports on host
  * [x] Add optional `--hostname=x.y.z` that looks for the correct domain in DO, and creates an A domain record that points to the new droplet.
  * [x] If `--hostname=x.y.z` is specified, its value should be passed to the docker container as `--announce-hostname=x.y.z`
* [x] Add daemon installation section in the readme