### PR TITLE
chore(deps): fix ugorji dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,3 +39,5 @@ require (
 	gopkg.in/resty.v1 v1.10.3
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+replace github.com/ugorji/go v1.1.4 => github.com/ugorji/go/codec v0.0.0-20190204201341-e444a5086c43


### PR DESCRIPTION
ugorji seems to have moved their go.mod to the top level instead of the /codec package, thus breaking non-updated packages such as gin and gin/cors.