### PR TITLE
feat(object): add traversal method

### DIFF
--- a/pkg/object/hash.go
+++ b/pkg/object/hash.go
@@ -93,11 +93,11 @@ func (v Bytes) hash() Hash {
 func (v Map) hash() Hash {
 	// get all map keys
 	ks := []string{}
-	v.Iterate(func(k string, v Value) {
-		if strings.HasPrefix(k, "_") {
-			return
+	v.Iterate(func(k string, v Value) bool {
+		if !strings.HasPrefix(k, "_") {
+			ks = append(ks, k)
 		}
-		ks = append(ks, k)
+		return true
 	})
 	// sort them
 	sort.Strings(ks)
@@ -120,8 +120,9 @@ func (v Map) hash() Hash {
 
 func (v List) hash() Hash {
 	h := []byte{}
-	v.Iterate(func(v Value) {
+	v.Iterate(func(v Value) bool {
 		h = append(h, v.Hash()...)
+		return true
 	})
 	return hash(v.hint, h)
 }

--- a/pkg/object/list.go
+++ b/pkg/object/list.go
@@ -26,18 +26,28 @@ func (l List) Append(v Value) List {
 	}
 }
 
-func (l List) Iterate(f func(v Value)) {
+func (l List) iterate(f func(v Value) bool) bool {
 	if l.prev != nil {
-		l.prev.Iterate(f)
+		if !l.prev.iterate(f) {
+			return false
+		}
 	}
 	if l.value != nil {
-		f(l.value)
+		if !f(l.value) {
+			return false
+		}
 	}
+	return true
+}
+
+func (l List) Iterate(f func(v Value) bool) {
+	l.iterate(f)
 }
 
 func (l List) Length() (n int) {
-	l.Iterate(func(v Value) {
+	l.Iterate(func(v Value) bool {
 		n++
+		return true
 	})
 	return
 }
@@ -50,44 +60,51 @@ func (l List) PrimitiveHinted() interface{} {
 	switch {
 	case l.value.IsList():
 		p := []interface{}{}
-		l.Iterate(func(v Value) {
+		l.Iterate(func(v Value) bool {
 			p = append(p, v.PrimitiveHinted())
+			return true
 		})
 		return p
 	case l.value.IsMap():
 		p := []interface{}{}
-		l.Iterate(func(v Value) {
+		l.Iterate(func(v Value) bool {
 			p = append(p, v.PrimitiveHinted())
+			return true
 		})
 		return p
 	case l.value.IsBool():
 		p := []bool{}
-		l.Iterate(func(v Value) {
+		l.Iterate(func(v Value) bool {
 			p = append(p, v.PrimitiveHinted().(bool))
+			return true
 		})
 		return p
 	case l.value.IsString():
 		p := []string{}
-		l.Iterate(func(v Value) {
+		l.Iterate(func(v Value) bool {
 			p = append(p, v.PrimitiveHinted().(string))
+			return true
 		})
 		return p
 	case l.value.IsInt():
 		p := []int64{}
-		l.Iterate(func(v Value) {
+		l.Iterate(func(v Value) bool {
 			p = append(p, v.PrimitiveHinted().(int64))
+			return true
 		})
 		return p
 	case l.value.IsFloat():
 		p := []float64{}
-		l.Iterate(func(v Value) {
+		l.Iterate(func(v Value) bool {
 			p = append(p, v.PrimitiveHinted().(float64))
+			return true
 		})
 		return p
 	case l.value.IsBytes():
 		p := [][]byte{}
-		l.Iterate(func(v Value) {
+		l.Iterate(func(v Value) bool {
 			p = append(p, v.PrimitiveHinted().([]byte))
+			return true
 		})
 		return p
 	}

--- a/pkg/object/list_test.go
+++ b/pkg/object/list_test.go
@@ -11,8 +11,9 @@ func TestList(t *testing.T) {
 	require.Equal(t, 0, l.Length())
 
 	iCalls := 0
-	l.Iterate(func(_ Value) {
+	l.Iterate(func(_ Value) bool {
 		iCalls++
+		return true
 	})
 	require.Equal(t, 0, iCalls)
 
@@ -27,9 +28,10 @@ func TestList(t *testing.T) {
 
 	iCalls = 0
 	values := []string{}
-	l1.Iterate(func(v Value) {
+	l1.Iterate(func(v Value) bool {
 		iCalls++
 		values = append(values, v.PrimitiveHinted().(string))
+		return true
 	})
 	require.Equal(t, 2, iCalls)
 	require.Len(t, values, 2)

--- a/pkg/object/map.go
+++ b/pkg/object/map.go
@@ -1,12 +1,14 @@
 package object
 
+import "strconv"
+
 type Map struct {
 	m mapIterator
 }
 
 type mapIterator interface {
 	value(k string) Value
-	iterate(func(k string, v Value))
+	iterate(func(k string, v Value) bool) bool
 }
 
 type mapPair struct {
@@ -25,25 +27,62 @@ func (p mapPair) value(k string) Value {
 	return p.parent.value(k)
 }
 
-func (p mapPair) iterate(f func(k string, v Value)) {
-	f(p.k, p.v)
-	if p.parent == nil {
-		return
+func (p mapPair) iterate(f func(k string, v Value) bool) bool {
+	if !f(p.k, p.v) {
+		return false
 	}
-	p.parent.iterate(f)
+	if p.parent == nil {
+		return true
+	}
+	return p.parent.iterate(f)
 }
 
-func (m Map) Iterate(f func(k string, v Value)) {
+func (m Map) iterate(f func(k string, v Value) bool) bool {
 	if m.m == nil {
-		return
+		return true
 	}
 	seen := make(map[string]bool)
-	m.m.iterate(func(k string, v Value) {
+	return m.m.iterate(func(k string, v Value) bool {
+		cont := true
 		if !seen[k] {
-			f(k, v)
+			cont = f(k, v)
 			seen[k] = true
 		}
+		return cont
 	})
+}
+
+func (m Map) Iterate(f func(k string, v Value) bool) {
+	m.iterate(f)
+}
+
+func traverse(k string, v Value, f func(string, Value) bool) bool {
+	cont := f(k, v)
+	if !cont {
+		return false
+	}
+	if k != "" {
+		k += "."
+	}
+	switch cv := v.(type) {
+	case Map:
+		cont = cv.iterate(func(ik string, iv Value) bool {
+			cont = traverse(k+ik, iv, f)
+			return cont
+		})
+	case List:
+		i := 0
+		cont = cv.iterate(func(iv Value) bool {
+			cont = traverse(k+strconv.Itoa(i), iv, f)
+			i++
+			return cont
+		})
+	}
+	return cont
+}
+
+func Traverse(v Value, f func(string, Value) bool) {
+	traverse("", v, f)
 }
 
 func (m Map) Value(k string) Value {
@@ -68,8 +107,9 @@ func (m Map) PrimitiveHinted() interface{} {
 		return nil
 	}
 	p := map[string]interface{}{}
-	m.Iterate(func(k string, v Value) {
+	m.Iterate(func(k string, v Value) bool {
 		p[k] = v.PrimitiveHinted()
+		return true
 	})
 	return p
 }

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -162,12 +162,13 @@ func (o Object) GetSignatures() []Signature {
 	sigs := []Signature{}
 	if os := o.get("_signatures:am"); os != nil {
 		if ol, ok := os.(List); ok && ol.Length() > 0 {
-			ol.Iterate(func(v Value) {
+			ol.Iterate(func(v Value) bool {
 				m, ok := v.(Map)
 				if !ok {
-					return
+					return true
 				}
 				sigs = append(sigs, immutableMapToSignature(m))
+				return true
 			})
 		}
 	}


### PR DESCRIPTION
Adds a cancelable traversal method for immutable values.
Closes #416 

```go
m := Map{}.
	Set("foo0:s", String("bar0")).
	Set("foo1:s", String("bar1"))

Traverse(m, func(k string, v Value) {
	fmt.Println(k, v)
}
```