### PR TITLE
refactor(makefile): reduce unnecessary tool installation and builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+bin/*
+vendor/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
         with:
           version: v1.31
         env:
-          CI: "true"
           VERBOSE: "true"
 
   tidy:
@@ -48,7 +47,6 @@ jobs:
         run: make test
         env:
           GOMAXPROCS: 4
-          CI: "true"
           VERBOSE: "true"
 
   cover:
@@ -63,16 +61,20 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v1
 
+        # Required as deps installation within paambaati/codeclimate-action
+        # fails for reasons unknown.
+      - name: Ensure go-acc is available
+        run: make go-acc
+
       - name: Publish coverage
         uses: paambaati/codeclimate-action@v2.6.0
         env:
-          CI: "true"
           VERBOSE: "true"
           GOMAXPROCS: 4
           CC_TEST_REPORTER_ID: 085aacaf8f700db084131fa4b223c9d27718d864f26a668cd1993d46868524ac
         with:
           debug: true
-          coverageCommand: make tools cover-codeclimate
+          coverageCommand: make cover-codeclimate
           coverageLocations: |
             ${{github.workspace}}/coverage.out:gocov
   e2e:
@@ -90,7 +92,6 @@ jobs:
       - name: Make e2e
         run: make e2e
         env:
-          CI: "true"
           VERBOSE: "true"
 
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /src/nimona.io
 ENV CGO_ENABLED=1
 ENV VERSION=$version
 
-ADD . .
+COPY . .
 
 RUN make build
 RUN make build-examples

--- a/internal/connmanager/connmanager.go
+++ b/internal/connmanager/connmanager.go
@@ -10,8 +10,8 @@ import (
 	"nimona.io/pkg/peer"
 )
 
-//go:generate $GOBIN/genny -in=$GENERATORS/syncmap_named/syncmap.go -out=addresses_generated.go -pkg=connmanager gen "KeyType=string ValueType=addressState SyncmapName=addresses"
-//go:generate $GOBIN/genny -in=$GENERATORS/syncmap_named/syncmap.go -out=connections_generated.go -imp=nimona.io/pkg/crypto -pkg=connmanager gen "KeyType=crypto.PublicKey ValueType=peerbox SyncmapName=connections"
+//go:generate genny -in=$GENERATORS/syncmap_named/syncmap.go -out=addresses_generated.go -pkg=connmanager gen "KeyType=string ValueType=addressState SyncmapName=addresses"
+//go:generate genny -in=$GENERATORS/syncmap_named/syncmap.go -out=connections_generated.go -imp=nimona.io/pkg/crypto -pkg=connmanager gen "KeyType=crypto.PublicKey ValueType=peerbox SyncmapName=connections"
 
 type addressState int
 

--- a/pkg/blob/blobmanager.go
+++ b/pkg/blob/blobmanager.go
@@ -14,7 +14,7 @@ import (
 	"nimona.io/pkg/sqlobjectstore"
 )
 
-//go:generate $GOBIN/genny -in=$GENERATORS/syncmap_named/syncmap.go -out=requests_generated.go -pkg=blob gen "KeyType=string ValueType=request SyncmapName=requests"
+//go:generate genny -in=$GENERATORS/syncmap_named/syncmap.go -out=requests_generated.go -pkg=blob gen "KeyType=string ValueType=request SyncmapName=requests"
 const (
 	peerLookupTime = 5
 )

--- a/pkg/localpeer/localpeer.go
+++ b/pkg/localpeer/localpeer.go
@@ -8,11 +8,11 @@ import (
 	"nimona.io/pkg/peer"
 )
 
-//go:generate $GOBIN/mockgen -destination=../localpeermock/localpeermock_generated.go -package=localpeermock -source=localpeer.go
-//go:generate $GOBIN/genny -in=$GENERATORS/synclist/synclist.go -out=contenthashes_generated.go -imp=nimona.io/pkg/object -pkg=localpeer gen "KeyType=object.Hash"
-//go:generate $GOBIN/genny -in=$GENERATORS/synclist/synclist.go -out=relays_generated.go -imp=nimona.io/pkg/peer -pkg=localpeer gen "KeyType=*peer.Peer"
-//go:generate $GOBIN/genny -in=$GENERATORS/synclist/synclist.go -out=certificates_generated.go -imp=nimona.io/pkg/peer -pkg=localpeer gen "KeyType=*object.Certificate"
-//go:generate $GOBIN/genny -in=$GENERATORS/synclist/synclist.go -out=addresses_generated.go -imp=nimona.io/pkg/peer -pkg=localpeer gen "KeyType=string"
+//go:generate mockgen -destination=../localpeermock/localpeermock_generated.go -package=localpeermock -source=localpeer.go
+//go:generate genny -in=$GENERATORS/synclist/synclist.go -out=contenthashes_generated.go -imp=nimona.io/pkg/object -pkg=localpeer gen "KeyType=object.Hash"
+//go:generate genny -in=$GENERATORS/synclist/synclist.go -out=relays_generated.go -imp=nimona.io/pkg/peer -pkg=localpeer gen "KeyType=*peer.Peer"
+//go:generate genny -in=$GENERATORS/synclist/synclist.go -out=certificates_generated.go -imp=nimona.io/pkg/peer -pkg=localpeer gen "KeyType=*object.Certificate"
+//go:generate genny -in=$GENERATORS/synclist/synclist.go -out=addresses_generated.go -imp=nimona.io/pkg/peer -pkg=localpeer gen "KeyType=string"
 
 type (
 	LocalPeer interface {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -27,7 +27,7 @@ import (
 	"nimona.io/pkg/peer"
 )
 
-//go:generate $GOBIN/mockgen -destination=../networkmock/networkmock_generated.go -package=networkmock -source=network.go
+//go:generate mockgen -destination=../networkmock/networkmock_generated.go -package=networkmock -source=network.go
 
 var (
 	dataForwardType   = new(DataForward).Type()
@@ -74,8 +74,8 @@ const (
 )
 
 // nolint: lll
-//go:generate $GOBIN/genny -in=$GENERATORS/syncmap_named/syncmap.go -out=outboxes_generated.go -imp=nimona.io/pkg/crypto -pkg=network gen "KeyType=crypto.PublicKey ValueType=outbox SyncmapName=outboxes"
-//go:generate $GOBIN/genny -in=$GENERATORS/pubsub/pubsub.go -out=pubsub_envelopes_generated.go -pkg=network gen "ObjectType=*Envelope Name=Envelope name=envelope"
+//go:generate genny -in=$GENERATORS/syncmap_named/syncmap.go -out=outboxes_generated.go -imp=nimona.io/pkg/crypto -pkg=network gen "KeyType=crypto.PublicKey ValueType=outbox SyncmapName=outboxes"
+//go:generate genny -in=$GENERATORS/pubsub/pubsub.go -out=pubsub_envelopes_generated.go -pkg=network gen "ObjectType=*Envelope Name=Envelope name=envelope"
 
 type (
 	// Network interface for mocking

--- a/pkg/objectmanager/objectmanager.go
+++ b/pkg/objectmanager/objectmanager.go
@@ -34,10 +34,10 @@ var (
 	streamAnnouncementType = new(stream.Announcement).Type()
 )
 
-//go:generate $GOBIN/mockgen -destination=../objectmanagermock/objectmanagermock_generated.go -package=objectmanagermock -source=objectmanager.go
-//go:generate $GOBIN/mockgen -destination=../objectmanagerpubsubmock/objectmanagerpubsubmock_generated.go -package=objectmanagerpubsubmock -source=pubsub_generated.go
-//go:generate $GOBIN/genny -in=$GENERATORS/pubsub/pubsub.go -out=pubsub_generated.go -pkg objectmanager -imp=nimona.io/pkg/object gen "ObjectType=*object.Object Name=Object name=object"
-//go:generate $GOBIN/genny -in=$GENERATORS/syncmap_named/syncmap.go -out=subscriptions_generated.go -imp=nimona.io/pkg/crypto -pkg=objectmanager gen "KeyType=object.Hash ValueType=stream.Subscription SyncmapName=subscriptions"
+//go:generate mockgen -destination=../objectmanagermock/objectmanagermock_generated.go -package=objectmanagermock -source=objectmanager.go
+//go:generate mockgen -destination=../objectmanagerpubsubmock/objectmanagerpubsubmock_generated.go -package=objectmanagerpubsubmock -source=pubsub_generated.go
+//go:generate genny -in=$GENERATORS/pubsub/pubsub.go -out=pubsub_generated.go -pkg objectmanager -imp=nimona.io/pkg/object gen "ObjectType=*object.Object Name=Object name=object"
+//go:generate genny -in=$GENERATORS/syncmap_named/syncmap.go -out=subscriptions_generated.go -imp=nimona.io/pkg/crypto -pkg=objectmanager gen "KeyType=object.Hash ValueType=stream.Subscription SyncmapName=subscriptions"
 
 type (
 	ObjectManager interface {

--- a/pkg/objectstore/objectstore.go
+++ b/pkg/objectstore/objectstore.go
@@ -12,7 +12,7 @@ const (
 	ErrNotFound = errors.Error("not found")
 )
 
-//go:generate $GOBIN/mockgen -destination=../objectstoremock/objectstoremock_generated.go -package=objectstoremock -source=objectstore.go
+//go:generate mockgen -destination=../objectstoremock/objectstoremock_generated.go -package=objectstoremock -source=objectstore.go
 
 type (
 	Getter interface {

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -33,7 +33,7 @@ const (
 	ErrNoPeersToAsk = errors.Error("no peers to ask")
 )
 
-//go:generate $GOBIN/mockgen -destination=../resolvermock/resolvermock_generated.go -package=resolvermock -source=resolver.go
+//go:generate mockgen -destination=../resolvermock/resolvermock_generated.go -package=resolvermock -source=resolver.go
 
 type (
 	Resolver interface {


### PR DESCRIPTION
- Define distinct targets for each of the external tools needed, which
  correctly detect if the binary is available or not.
- Ensure all targets which depend on tools lists the tools in their
  dependencies, so required tools are automatically installed if
  missing.
- Ensure environment variables are correctly set for shell that executes
  targets. The export directive previously used only works on GNU Make,
  and not BSD Make which comes with macOS. The workaround for this is
  setting the SHELL make variable to include the environment variables
  needed.