### PR TITLE
fix(cover): use go tool cover instead of go-acc to generate coverage data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,22 +61,18 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v1
 
-        # Required as deps installation within paambaati/codeclimate-action
-        # fails for reasons unknown.
-      - name: Ensure go-acc is available
-        run: make go-acc
-
       - name: Publish coverage
-        uses: paambaati/codeclimate-action@v2.6.0
+        uses: paambaati/codeclimate-action@v2.7.4
         env:
           VERBOSE: "true"
           GOMAXPROCS: 4
           CC_TEST_REPORTER_ID: 085aacaf8f700db084131fa4b223c9d27718d864f26a668cd1993d46868524ac
         with:
-          debug: true
-          coverageCommand: make cover-codeclimate
+          coverageCommand: make cover
+          prefix: nimona.io
           coverageLocations: |
             ${{github.workspace}}/coverage.out:gocov
+
   e2e:
     name: E2E tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           VERBOSE: "true"
           GOMAXPROCS: 4
-          CC_TEST_REPORTER_ID: 085aacaf8f700db084131fa4b223c9d27718d864f26a668cd1993d46868524ac
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           coverageCommand: make cover
           prefix: nimona.io

--- a/internal/connmanager/connmanager_test.go
+++ b/internal/connmanager/connmanager_test.go
@@ -26,7 +26,7 @@ func TestGetConnection(t *testing.T) {
 
 	mgr := New(ctx, n1, handler)
 
-	lst1, err := n1.Listen(ctx, "0.0.0.0:0", &net.ListenConfig{
+	lst1, err := n1.Listen(ctx, "127.0.0.1:0", &net.ListenConfig{
 		BindLocal: true,
 	})
 	assert.NoError(t, err)
@@ -35,7 +35,7 @@ func TestGetConnection(t *testing.T) {
 	mgr2 := New(ctx, n2, handler)
 	assert.NotNil(t, mgr2)
 
-	lst2, err := n2.Listen(ctx, "0.0.0.0:0", &net.ListenConfig{
+	lst2, err := n2.Listen(ctx, "127.0.0.1:0", &net.ListenConfig{
 		BindLocal: true,
 	})
 	assert.NoError(t, err)

--- a/internal/net/net_test.go
+++ b/internal/net/net_test.go
@@ -20,7 +20,7 @@ func TestNetConnectionSuccess(t *testing.T) {
 	kc1, n1 := newPeer(t)
 	_, n2 := newPeer(t)
 
-	_, err := n1.Listen(ctx, "0.0.0.0:0", &ListenConfig{
+	_, err := n1.Listen(ctx, "127.0.0.1:0", &ListenConfig{
 		BindLocal: true,
 	})
 	assert.NoError(t, err)

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -13,6 +13,8 @@ func Test_TestNestedNamedOutput(t *testing.T) {
 	r0, w0, _ := os.Pipe()
 	r1, w1, _ := os.Pipe()
 
+	DefaultLogLevel = DebugLevel
+
 	logger := New()
 	logger.SetOutput(w0)
 	logger.Debug("foo")

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -16,11 +16,11 @@ func TestNetwork_SimpleConnection(t *testing.T) {
 	n1 := New(context.Background())
 	n2 := New(context.Background())
 
-	l1, err := n1.Listen(context.Background(), "0.0.0.0:0", ListenOnLocalIPs)
+	l1, err := n1.Listen(context.Background(), "127.0.0.1:0", ListenOnLocalIPs)
 	require.NoError(t, err)
 	defer l1.Close()
 
-	l2, err := n2.Listen(context.Background(), "0.0.0.0:0", ListenOnLocalIPs)
+	l2, err := n2.Listen(context.Background(), "127.0.0.1:0", ListenOnLocalIPs)
 	require.NoError(t, err)
 	defer l2.Close()
 
@@ -83,7 +83,7 @@ func TestNetwork_Relay(t *testing.T) {
 	n1 := New(context.Background())
 	n2 := New(context.Background())
 
-	l0, err := n0.Listen(context.Background(), "0.0.0.0:0", ListenOnLocalIPs)
+	l0, err := n0.Listen(context.Background(), "127.0.0.1:0", ListenOnLocalIPs)
 	require.NoError(t, err)
 	defer l0.Close()
 


### PR DESCRIPTION
When using go-acc it seems to duplicate coverage data multiple times
with different coverage numbers. This seems to confuse tools like
CodeClimate. So let's simplify and just use Go's built-in cover tool
instead.

Also bind tests to 127.0.0.1 instead of 0.0.0.0.